### PR TITLE
fix: Made sort order optional.

### DIFF
--- a/entegywrapper/schemas/content.py
+++ b/entegywrapper/schemas/content.py
@@ -141,7 +141,7 @@ class Content(BaseModel):
     mainImage: str
     strings: dict[StringKey, str]
     pageSettings: dict[PageSetting, bool]
-    sortOrder: int
+    sortOrder: Optional[int] = None
 
 
 class ContentPage(Content):

--- a/entegywrapper/schemas/profile.py
+++ b/entegywrapper/schemas/profile.py
@@ -85,7 +85,7 @@ class CustomProfileField(BaseModel):
     userAccess: str
     profileVisibility: str
     type: CustomProfileFieldType
-    sortOrder: int
+    sortOrder: Optional[int] = None
     externallyManaged: bool
     options: Optional[list[MultiChoiceOptions]]
 


### PR DESCRIPTION
The following is an example profile custom field record that comes back from Entegy:

```
{'key': 'agebracket', 'name': 'Age bracket', 'required': True, 'userAccess': 'Editable', 'profileVisibility': 'Hidden', 'type': 'MultiChoice', 'externallyManaged': False, 'minSelections': 1, 'maxSelections': 1, 'isDemographicField': True, 'options': [{...}, {...}, {...}, {...}, {...}, {...}, {...}]}
```

Note the lack of sortOrder.
I'm going to assume the variable was added for a reason so have left it as optional.

Tested by running the test suite in integro-backend with this change in place in the wrapper.

Note that I also made the same change to content - I've assumed consistency in Entegy's backend.