### PR TITLE
Ensure profiles are yielded for every page

### DIFF
--- a/entegywrapper/profiles/profiles.py
+++ b/entegywrapper/profiles/profiles.py
@@ -76,8 +76,8 @@ def all_profiles(
 
         response = self.post(self.api_endpoint + "/v2/Profile/All", data=data)
 
-    for profile in response["profiles"]:
-        yield Profile(**profile)
+        for profile in response["profiles"]:
+            yield Profile(**profile)
 
 
 def get_profile(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "entegywrapper"
-version = "7.0.2"
+version = "7.1.0"
 requires-python = ">=3.10"
 
 [tool.black]
@@ -16,7 +16,7 @@ profile = "black"
 
 [tool.poetry]
 name = "entegywrapper"
-version = "7.0.2"
+version = "7.1.0"
 description = "Python SDK for the Entegy API"
 authors = [
     "Situ Development <developer@situ.com.au>",


### PR DESCRIPTION
Fixes #190. This issue was indentation-based: instead of the second generation being part of the iteration, it occurred after the completion of the iteration. This meant only the first and last pages were generated, not the full collection