### PR TITLE
Improved robustness of results and error collection.

### DIFF
--- a/entegywrapper/__init__.py
+++ b/entegywrapper/__init__.py
@@ -7,8 +7,9 @@ from json import JSONEncoder
 from typing import Any, Callable
 
 import requests
-from entegywrapper.errors import EntegyInvalidAPIKeyError, EntegyNoDataError
 from requests.structures import CaseInsensitiveDict
+
+from entegywrapper.errors import EntegyInvalidAPIKeyError, EntegyNoDataError
 
 sys.path.append(os.path.dirname(__file__))
 

--- a/entegywrapper/__init__.py
+++ b/entegywrapper/__init__.py
@@ -7,9 +7,8 @@ from json import JSONEncoder
 from typing import Any, Callable
 
 import requests
-from requests.structures import CaseInsensitiveDict
-
 from entegywrapper.errors import EntegyInvalidAPIKeyError, EntegyNoDataError
+from requests.structures import CaseInsensitiveDict
 
 sys.path.append(os.path.dirname(__file__))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "entegywrapper"
-version = "7.2.0"
+version = "7.2.1"
 requires-python = ">=3.10"
 
 [tool.black]
@@ -16,7 +16,7 @@ profile = "black"
 
 [tool.poetry]
 name = "entegywrapper"
-version = "7.2.0"
+version = "7.2.1"
 description = "Python SDK for the Entegy API"
 authors = [
     "Situ Development <developer@situ.com.au>",


### PR DESCRIPTION
## Description

Fixes the following issue:

```
Traceback (most recent call last):
  File "/var/www/integro-backend/integro_backend/__init__.py", line 27, in main
    Job(sync).run()
  File "/var/www/integro-backend/integro_backend/job.py", line 146, in run
    self.destination.sync_data(**data)
  File "/var/www/integro-backend/integro_backend/destinations/entegy/__init__.py", line 109, in sync_data
    self.profile_sync(**data)
  File "/var/www/integro-backend/integro_backend/destinations/entegy/__init__.py", line 184, in profile_sync
    self.sync_profiles(entegy_profiles, send_welcome_email)
  File "/var/www/integro-backend/integro_backend/destinations/entegy/profiles/__init__.py", line 133, in sync_profiles
    response = self.api.sync_profiles(
  File "/var/www/integro-backend/venvs/integro-backend-LrOY0ySZ-py3.10/lib/python3.10/site-packages/entegywrapper/profiles/profiles.py", line 368, in sync_profiles
    result["results"].extend(response["results"])
KeyError: 'results'
```

## Type of change

-   [x] Bug fix (non-breaking change which fixes a bug)
-   [ ] Chore (non-breaking change that refactors, tidies up or formats code)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

New code runs fine with profile creation that produces no results.

## Checklist:

-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

