### PR TITLE
Update Publish Workflow Permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,9 +4,6 @@ on:
   push:
     branches: main
 
-permissions:
-  contents: read
-
 jobs:
   check-version:
     runs-on: ubuntu-latest
@@ -25,8 +22,6 @@ jobs:
       GH_TOKEN: ${{ secrets.RELEASE_PAT }}
     if: ${{ fromJson(needs.check-version.outputs.is-greater) }}
     needs: check-version
-    permissions:
-      id-token: write
     steps:
       - uses: actions/checkout@v4
       - run: gh release create --generate-notes --target main "v${{ needs.check-version.outputs.version }}"
@@ -39,6 +34,7 @@ jobs:
     if: ${{ fromJson(needs.check-version.outputs.is-greater) }}
     needs: check-version
     permissions:
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
`contents: read` is provided by default, so specifying this at the top level only removes other default permissions.

Creating a GitHub release does not require an OIDC token.

`id-token: write` on the PyPI release job removes the default `contents: read` permission. This is not a problem while this repository is public, but this permission is added explicitly to ensure access if it is made private